### PR TITLE
fix: fix request and response header values set to header names when the value is a string

### DIFF
--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -146,7 +146,7 @@ Napi::Value Transaction::addRequestHeader(const Napi::CallbackInfo& info)
             auto buf = info[1].As<Napi::Buffer<char>>();
             value    = string_view(buf.Data(), buf.Length());
         } else {
-            v     = info[0].ToString().Utf8Value();
+            v     = info[1].ToString().Utf8Value();
             value = string_view(v);
         }
 
@@ -265,7 +265,7 @@ Napi::Value Transaction::addResponseHeader(const Napi::CallbackInfo& info)
             auto buf = info[1].As<Napi::Buffer<char>>();
             value    = string_view(buf.Data(), buf.Length());
         } else {
-            v     = info[0].ToString().Utf8Value();
+            v     = info[1].ToString().Utf8Value();
             value = string_view(v);
         }
 


### PR DESCRIPTION
I saw in ModSecurity audit log when creating a ModSecurity integration module for my web server software that the header values are set to header names.
I used string header names, and string values, as the example code suggests (req.rawHeaders is an array of strings).
I checked the C++ source code, and it turns out that there is a typo in the code that causes header values to be always header names if the header value is a string.
So I modified the source code to fix the bug.